### PR TITLE
only index into host array if element exists

### DIFF
--- a/go/refererparser.go
+++ b/go/refererparser.go
@@ -85,7 +85,11 @@ func lookup(uri *url.URL, q string, suffix bool) (refResult *RefererResult) {
 func Parse(uri string) (refResult *RefererResult) {
 	puri, _ := url.Parse(uri)
 	// Split before the first dot ".".
-	rhost := strings.SplitAfterN(puri.Host, ".", 2)[1]
+	parts := strings.SplitAfterN(puri.Host, ".", 2)
+	rhost := ""
+	if len(parts) > 1 {
+		rhost = parts[1]
+	}
 	queries := []string{puri.Host + puri.Path, rhost + puri.Path, puri.Host, rhost}
 	for _, q := range queries {
 		refResult = lookup(puri, q, false)

--- a/go/refererparser_test.go
+++ b/go/refererparser_test.go
@@ -236,6 +236,14 @@ var testData = []struct {
 		"",
 		false,
 	},
+	{
+		"Referrer with no dot in host",
+		"http://localhost/search?q=test",
+		"unknown",
+		"",
+		"",
+		false,
+	},
 }
 
 func check(err error) {


### PR DESCRIPTION
the added test will have a runtime panic without the patched `refererparser.go`