### PR TITLE
Search & mail provider updates

### DIFF
--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -97,10 +97,10 @@ email:
     domains:
       - webmail.commander.net.au
 
-  Daum Mail:
+  Daum:
     domains:
       - mail2.daum.net
-      - m.mail.daum.net
+      - mail.daum.net
 
   Dodo:
     domains:
@@ -2881,14 +2881,7 @@ search:
     parameters:
       - q
     domains:
-      - airzip.inspsearch.com
-      - airzip2.inspsearch.com
-      - viview.inspsearch.com
-      - kingtale2.inspsearch.com
-      - kingtale3.inspsearch.com
-      - govome.inspsearch.com
-      - govome2.inspsearch.com
-      - globososo.inspsearch.com
+      - inspsearch.com
 
   Interia:
     parameters:

--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -2888,7 +2888,7 @@ search:
       - search.searchcompletion.com
       - clusty.com
 
-  Insp Search:
+  Flyingbird:
     parameters:
       - q
     domains:

--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -3317,13 +3317,9 @@ search:
   Sogou:
     parameters:
       - query
-    domains:
-      - www.sougou.com
-
-  Sogou:
-    parameters:
       - w
     domains:
+      - www.sougou.com
       - www.soso.com
 
   Softonic:

--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -113,11 +113,16 @@ email:
   Gmail:
     domains:
       - mail.google.com
+      - inbox.google.com
 
   iiNet:
     domains:
       - webmail.iinet.net.au
       - mail.iinet.net.au
+
+  Inbox.com:
+    domains:
+      - inbox.com
 
   iPrimus:
     domains:
@@ -2857,6 +2862,12 @@ search:
       - search_for
     domains:
       - www.ilse.nl
+
+  Inbox.com:
+    parameters:
+      - q
+    domains:
+      - inbox.com/search/
 
   InfoSpace:
     parameters:

--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -75,6 +75,14 @@ email:
     domains:
       - mail.163.com
 
+  2degrees:
+    domains:
+      - webmail.2degreesbroadband.co.nz
+
+  Adam Internet:
+    domains:
+      - webmail.adam.com.au
+
   AOL Mail:
     domains:
       - mail.aol.com
@@ -83,22 +91,54 @@ email:
     domains:
       - webmail.bigpond.com
       - webmail2.bigpond.com
+      - email.telstra.com
+
+  Commander:
+    domains:
+      - webmail.commander.net.au
 
   Daum Mail:
     domains:
       - mail2.daum.net
+      - m.mail.daum.net
+
+  Dodo:
+    domains:
+      - webmail.dodo.com.au
+
+  Freenet:
+    domains:
+      - webmail.freenet.de
 
   Gmail:
     domains:
       - mail.google.com
 
-  Naver Mail:
+  iiNet:
+    domains:
+      - webmail.iinet.net.au
+      - mail.iinet.net.au
+
+  iPrimus:
+    domains:
+      - webmail.iprimus.com.au
+
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
+
+  Naver:
     domains:
       - mail.naver.com
 
-  Optus Zoo:
+  Netspace:
     domains:
-      - webmail.optuszoo.com.au  
+      - webmail.netspace.net.au
+
+  Optus:
+    domains:
+      - webmail.optuszoo.com.au
+      - webmail.optusnet.com.au
 
   Orange Webmail:
     domains:
@@ -107,14 +147,27 @@ email:
   Outlook.com:
     domains:
       - mail.live.com
+      - outlook.live.com
 
   QQ Mail:
     domains:
-      - mail.qq.com  
+      - mail.qq.com
 
   Seznam Mail:
     domains:
-      - email.seznam.cz  
+      - email.seznam.cz
+
+  Virgin:
+    domains:
+      - webmail.virginbroadband.com.au
+
+  Vodafone:
+    domains:
+      - webmail.vodafone.co.nz
+
+  Westnet:
+    domains:
+      - webmail.westnet.com.au
 
   Yahoo! Mail:
     domains:
@@ -122,11 +175,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
-      
-  Mynet Mail:
-    domains:
-      - mail.mynet.com
 
+  Zoho:
+    domains:
+      - mail.zoho.com
 
 # #######################################################################################################
 #
@@ -419,38 +471,38 @@ social:
   Pocket:
     domains:
       - getpocket.com
-      
+
     ITU Sozluk:
     domains:
       - itusozluk.com
-      
+
   Instela:
     domains:
       - instela.com
-      
+
   Eksi Sozluk:
     domains:
       - Sozluk.com
       - sourtimes.org
-  
+
   Uludag Sozluk:
     domains:
       - uludagsozluk.com
       - ulusozluk.com
-  
+
   Inci Sozluk:
     domains:
       - inci.sozlukspot.com
       - incisozluk.com
       - incisozluk.cc
-  
+
   Hocam.com:
     domains:
       - hocam.com
-      
+
   Donanimhaber:
     domains:
-      - donanimhaber.com 
+      - donanimhaber.com
 
   Disqus:
     domains:
@@ -475,6 +527,12 @@ search:
       - 1.cz
 
   # 123people TODO
+
+  1&1:
+    parameters:
+      - q
+    domains:
+      - search.1and1.com
 
   1und1:
     parameters:
@@ -747,6 +805,12 @@ search:
     domains:
       - search.bluewin.ch
 
+  British Telecommunications:
+    parameters:
+      - p
+    domains:
+      - search.bt.com
+
   canoe.ca:
     parameters:
       - q
@@ -870,6 +934,12 @@ search:
       - dmoz.org
       - editors.dmoz.org
 
+  Dodo:
+    parameters:
+      - q
+    domains:
+      - google.dodo.com.au
+
   DuckDuckGo:
     parameters:
       - q
@@ -951,6 +1021,12 @@ search:
       - name
     domains:
       - recherche.francite.com
+
+  Finderoo:
+    parameters:
+      - q
+    domains:
+      - www.finderoo.com
 
   Findwide:
     parameters:
@@ -2801,6 +2877,19 @@ search:
       - search.searchcompletion.com
       - clusty.com
 
+  Insp Search:
+    parameters:
+      - q
+    domains:
+      - airzip.inspsearch.com
+      - airzip2.inspsearch.com
+      - viview.inspsearch.com
+      - kingtale2.inspsearch.com
+      - kingtale3.inspsearch.com
+      - govome.inspsearch.com
+      - govome2.inspsearch.com
+      - globososo.inspsearch.com
+
   Interia:
     parameters:
       - q
@@ -3158,6 +3247,12 @@ search:
 
   # Add Scour.com
 
+  Search This:
+    parameters:
+      - q
+    domains:
+      - www.searchthis.com
+
   Search.com:
     parameters:
       - q
@@ -3208,11 +3303,24 @@ search:
     domains:
       - www.skynet.be
 
+  The Smart Search:
+    parameters:
+      - q
+    domains:
+      - thesmartsearch.net
+      - www.thesmartsearch.net
+
   Sogou:
     parameters:
       - query
     domains:
       - www.sougou.com
+
+  Sogou:
+    parameters:
+      - w
+    domains:
+      - www.soso.com
 
   Softonic:
     parameters:
@@ -3220,11 +3328,12 @@ search:
     domains:
       - search.softonic.com
 
-  soso.com:
+  SoSoDesk:
     parameters:
-      - w
+      - q
     domains:
-      - www.soso.com
+      - sosodesktop.com
+      - search.sosodesktop.com
 
   Snapdo:
     parameters:
@@ -3273,6 +3382,12 @@ search:
       - q
     domains:
       - technorati.com
+
+  Telstra:
+    parameters:
+      - find
+    domains:
+      - search.media.telstra.com.au
 
   Teoma:
     parameters:


### PR DESCRIPTION
Based on our Snowplow Analytics data I added some missing search / email providers.

Tons of additions mostly for sites popular in APAC. I merged Sogou and SoSo.com because Tencent are redirecting them to Sogou now. Also I made some changes to Naver and Daum  source names based on another issue I raised here https://github.com/snowplow/referer-parser/issues/132

E.g. Better to have "Naver" than "Naver Mail", "Naver Search" and "Naver Cafe" etc...