### PR TITLE
Updating search and mail referrers list

### DIFF
--- a/resources/referers.yml
+++ b/resources/referers.yml
@@ -75,6 +75,14 @@ email:
     domains:
       - mail.163.com
 
+  2degrees:
+    domains:
+      - webmail.2degreesbroadband.co.nz
+
+  Adam Internet:
+    domains:
+      - webmail.adam.com.au
+
   AOL Mail:
     domains:
       - mail.aol.com
@@ -83,22 +91,60 @@ email:
     domains:
       - webmail.bigpond.com
       - webmail2.bigpond.com
+      - email.telstra.com
+      - basic.messaging.bigpond.com
+
+  Commander:
+    domains:
+      - webmail.commander.net.au
 
   Daum Mail:
     domains:
       - mail2.daum.net
+      - mail.daum.net
+
+  Dodo:
+    domains:
+      - webmail.dodo.com.au
+
+  Freenet:
+    domains:
+      - webmail.freenet.de
 
   Gmail:
     domains:
       - mail.google.com
+      - inbox.google.com
+
+  iiNet:
+    domains:
+      - webmail.iinet.net.au
+      - mail.iinet.net.au
+
+  Inbox.com:
+    domains:
+      - inbox.com
+
+  iPrimus:
+    domains:
+      - webmail.iprimus.com.au
+
+  Mynet Mail:
+    domains:
+      - mail.mynet.com
 
   Naver Mail:
     domains:
       - mail.naver.com
 
+  Netspace:
+    domains:
+      - webmail.netspace.net.au
+
   Optus Zoo:
     domains:
-      - webmail.optuszoo.com.au  
+      - webmail.optuszoo.com.au
+      - webmail.optusnet.com.au
 
   Orange Webmail:
     domains:
@@ -107,6 +153,7 @@ email:
   Outlook.com:
     domains:
       - mail.live.com
+      - outlook.live.com
 
   QQ Mail:
     domains:
@@ -114,7 +161,19 @@ email:
 
   Seznam Mail:
     domains:
-      - email.seznam.cz  
+      - email.seznam.cz
+
+  Virgin:
+    domains:
+      - webmail.virginbroadband.com.au
+
+  Vodafone:
+    domains:
+      - webmail.vodafone.co.nz
+
+  Westnet:
+    domains:
+      - webmail.westnet.com.au
 
   Yahoo! Mail:
     domains:
@@ -122,11 +181,10 @@ email:
       - mail.yahoo.com
       - mail.yahoo.co.uk
       - mail.yahoo.co.jp
-      
-  Mynet Mail:
-    domains:
-      - mail.mynet.com
 
+  Zoho:
+    domains:
+      - mail.zoho.com
 
 # #######################################################################################################
 #
@@ -419,35 +477,35 @@ social:
   Pocket:
     domains:
       - getpocket.com
-      
+
     ITU Sozluk:
     domains:
       - itusozluk.com
-      
+
   Instela:
     domains:
       - instela.com
-      
+
   Eksi Sozluk:
     domains:
       - Sozluk.com
       - sourtimes.org
-  
+
   Uludag Sozluk:
     domains:
       - uludagsozluk.com
       - ulusozluk.com
-  
+
   Inci Sozluk:
     domains:
       - inci.sozlukspot.com
       - incisozluk.com
       - incisozluk.cc
-  
+
   Hocam.com:
     domains:
       - hocam.com
-      
+
   Donanimhaber:
     domains:
       - donanimhaber.com 
@@ -462,6 +520,10 @@ social:
     domains:
       - quora.com
 
+    Whirlpool:
+      domains:
+        - forums.whirlpool.net.au
+
 # #######################################################################################################
 #
 # SEARCH PROVIDERS
@@ -475,6 +537,12 @@ search:
       - 1.cz
 
   # 123people TODO
+
+  1&1:
+    parameters:
+      - q
+    domains:
+      - search.1and1.com
 
   1und1:
     parameters:
@@ -747,6 +815,12 @@ search:
     domains:
       - search.bluewin.ch
 
+  British Telecommunications:
+    parameters:
+      - p
+    domains:
+      - search.bt.com
+
   canoe.ca:
     parameters:
       - q
@@ -870,6 +944,12 @@ search:
       - dmoz.org
       - editors.dmoz.org
 
+  Dodo:
+    parameters:
+      - q
+    domains:
+      - google.dodo.com.au
+
   DuckDuckGo:
     parameters:
       - q
@@ -951,6 +1031,12 @@ search:
       - name
     domains:
       - recherche.francite.com
+
+  Finderoo:
+    parameters:
+      - q
+    domains:
+      - www.finderoo.com
 
   Findwide:
     parameters:
@@ -2782,6 +2868,12 @@ search:
     domains:
       - www.ilse.nl
 
+  Inbox.com:
+    parameters:
+      - q
+    domains:
+      - inbox.com/search/
+
   InfoSpace:
     parameters:
       - q
@@ -2800,6 +2892,12 @@ search:
       - search.magnetic.com
       - search.searchcompletion.com
       - clusty.com
+
+  Flyingbird:
+    parameters:
+      - q
+    domains:
+      - inspsearch.com
 
   Interia:
     parameters:
@@ -3158,6 +3256,12 @@ search:
 
   # Add Scour.com
 
+  Search This:
+    parameters:
+      - q
+    domains:
+      - www.searchthis.com
+
   Search.com:
     parameters:
       - q
@@ -3208,11 +3312,20 @@ search:
     domains:
       - www.skynet.be
 
+  The Smart Search:
+    parameters:
+      - q
+    domains:
+      - thesmartsearch.net
+      - www.thesmartsearch.net
+
   Sogou:
     parameters:
       - query
+      - w
     domains:
       - www.sougou.com
+      - www.soso.com
 
   Softonic:
     parameters:
@@ -3220,11 +3333,12 @@ search:
     domains:
       - search.softonic.com
 
-  soso.com:
+  SoSoDesk:
     parameters:
-      - w
+      - q
     domains:
-      - www.soso.com
+      - sosodesktop.com
+      - search.sosodesktop.com
 
   Snapdo:
     parameters:
@@ -3273,6 +3387,12 @@ search:
       - q
     domains:
       - technorati.com
+
+  Telstra:
+    parameters:
+      - find
+    domains:
+      - search.media.telstra.com.au
 
   Teoma:
     parameters:


### PR DESCRIPTION
- Adding some ANZ's largest ISPs' web mail domains and search engine domains (Dodo, Telstra, Optus, 2degrees, iiNet, Virgin, Vodafone etc)
- Chinese Soso search engine merged under Sogou
- Various other search engines added (SosoDesk - unrelated to Soso)
- Moved a bunch of domains into alphabetical order to make management of the list a little easier in future
