### PR TITLE
Add android-app scheme to valid scheme list

### DIFF
--- a/ruby/lib/referer-parser/parser.rb
+++ b/ruby/lib/referer-parser/parser.rb
@@ -86,8 +86,8 @@ module RefererParser
     def parse(obj)
       url = obj.is_a?(URI) ? obj : URI.parse(obj.to_s)
 
-      if !['http', 'https'].include?(url.scheme)
-        raise InvalidUriError.new("Only HTTP and HTTPS schemes are supported -- #{url.scheme}") 
+      if !['android-app', 'http', 'https'].include?(url.scheme)
+        raise InvalidUriError.new("Only Android-App, HTTP and HTTPS schemes are supported -- #{url.scheme}")
       end
 
       data = { :known => false, :uri => url.to_s }


### PR DESCRIPTION
Addresses referer values such as: `android-app://com.google.android.gm`

https://github.com/snowplow/referer-parser/issues/131