### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Java/Scala: [![Build Status](https://travis-ci.org/snowplow/referer-parser.png)](https://travis-ci.org/snowplow/referer-parser)
 
-referer-parser is a database for extracting marketing attribution data (such as search terms) from referer URLs, inspired by the [ua-parser] [ua-parser] project (an equivalent library for user agent parsing).
+referer-parser is a database for extracting marketing attribution data (such as search terms) from referer URLs, inspired by the [ua-parser][ua-parser] project (an equivalent library for user agent parsing).
 
 The referer-parser project also contains multiple libraries for working with the referer-parser database in different languages.
 
-referer-parser is a core component of [Snowplow] [snowplow], the open-source web-scale analytics platform powered by Hadoop and Redshift.
+referer-parser is a core component of [Snowplow][snowplow], the open-source web-scale analytics platform powered by Hadoop and Redshift.
 
 _Note that we always use the original HTTP misspelling of 'referer' (and thus 'referal') in this project - never 'referrer'._
 
@@ -24,14 +24,14 @@ If there is an issue with the database necessitating a re-release within the mon
 
 ## Maintainers
 
-* Java/Scala: [Snowplow Analytics Ltd] [snowplow-analytics]
-* Ruby: [Kelley Reynolds] [kreynolds] at Inside Systems, Inc
-* Python: [Don Spaulding] [donspaulding]
-* node.js (JavaScript): [Martin Katrenik] [mkatrenik]
-* .NET (C#): [Sepp Wijnands] [swijnands] at [iPerform Software] [iperform]
-* PHP: [Lars Strojny] [lstrojny]
-* Go: [Thomas Sileo] [tsileo]
-* `referers.yml`: [Snowplow Analytics] [snowplow-analytics]
+* Java/Scala: [Snowplow Analytics Ltd][snowplow-analytics]
+* Ruby: [Kelley Reynolds][kreynolds] at Inside Systems, Inc
+* Python: [Don Spaulding][donspaulding]
+* node.js (JavaScript): [Martin Katrenik][mkatrenik]
+* .NET (C#): [Sepp Wijnands][swijnands] at [iPerform Software][iperform]
+* PHP: [Lars Strojny][lstrojny]
+* Go: [Thomas Sileo][tsileo]
+* `referers.yml`: [Snowplow Analytics][snowplow-analytics]
 
 ## Usage: Java
 
@@ -53,7 +53,7 @@ System.out.println(r.source);     // => "Google"
 System.out.println(r.term);       // => "gateway oracle cards denise linn"
 ```
 
-For more information, please see the Java/Scala [README] [java-scala-readme].
+For more information, please see the Java/Scala [README][java-scala-readme].
 
 ## Usage: Scala
 
@@ -97,7 +97,7 @@ for (r <- Parser.parse(refererUrl, pageUrl, internalDomains)) {
 }
 ```
 
-For more information, please see the Java/Scala [README] [java-scala-readme].
+For more information, please see the Java/Scala [README][java-scala-readme].
 
 ## Usage: Ruby
 
@@ -118,7 +118,7 @@ parser.parse('http://www.google.com/search?q=gateway+oracle+cards+denise+linn&hl
   }
 ```
 
-For more information, please see the Ruby [README] [ruby-readme].
+For more information, please see the Ruby [README][ruby-readme].
 
 ## Usage: Python
 
@@ -154,7 +154,7 @@ curr_url = 'http://www.snowplowanalytics.com/account/profile'
 r = Referer(referer_url, curr_url)
 ```
 
-For more information, please see the Python [README] [python-readme].
+For more information, please see the Python [README][python-readme].
 
 ## Usage: node.js
 
@@ -183,7 +183,7 @@ var current_url = 'http://www.snowplowanalytics.com/account/profile'
 var r = Referer(referer_url, current_url)
 ```
 
-For more information, please see the node.js [README] [nodejs-readme].
+For more information, please see the node.js [README][nodejs-readme].
 
 ## Usage: .NET
 
@@ -204,7 +204,7 @@ Console.WriteLine(r.Source); // => "Google"
 Console.WriteLine(r.Term); // => "gateway oracle cards denise linn"
 ```
 
-For more information, please see the .NET [README] [dotnet-readme].
+For more information, please see the .NET [README][dotnet-readme].
 
 ## Usage: PHP
 
@@ -226,7 +226,7 @@ if ($referer->isKnown()) {
 }
 ```
 
-For more information, please see the PHP [README] [php-readme].
+For more information, please see the PHP [README][php-readme].
 
 ## Usage: Go
 
@@ -255,11 +255,11 @@ func main() {
 
 ```
 
-For more information, please see the Go [README] [go-readme]
+For more information, please see the Go [README][go-readme]
 
 ## referers.yml
 
-referer-parser identifies whether a URL is a known referer or not by checking it against the [`referers.yml`] [referers-yml] file; the intention is that this YAML file is reusable as-is by every language-specific implementation of referer-parser.
+referer-parser identifies whether a URL is a known referer or not by checking it against the [`referers.yml`][referers-yml] file; the intention is that this YAML file is reusable as-is by every language-specific implementation of referer-parser.
 
 The file is broken out into sections for the different mediums that we support:
 
@@ -291,31 +291,31 @@ We welcome contributions to referer-parser:
 2. **Ports of referer-parser to other languages** - we welcome ports of referer-parser to new programming languages (e.g. Lua, Go, Haskell, C)
 3. **Bug fixes, feature requests etc** - much appreciated!
 
-**Please sign the [Snowplow CLA] [cla] before making pull requests.**
+**Please sign the [Snowplow CLA][cla] before making pull requests.**
 
 ## Support
 
 General support for referer-parser is handled by the team at Snowplow Analytics Ltd.
 
-You can contact the Snowplow Analytics team through any of the [channels listed on their wiki] [talk-to-us].
+You can contact the Snowplow Analytics team through any of the [channels listed on their wiki][talk-to-us].
 
 ## Copyright and license
 
-`referers.yml` is based on [Piwik's] [piwik] [`SearchEngines.php`] [piwik-search-engines] and [`Socials.php`] [piwik-socials], copyright 2012 Matthieu Aubry and available under the [GNU General Public License v3] [gpl-license].
+`referers.yml` is based on [Piwik's][piwik] [`SearchEngines.php`][piwik-search-engines] and [`Socials.php`][piwik-socials], copyright 2012 Matthieu Aubry and available under the [GNU General Public License v3][gpl-license].
 
-The Ruby implementation is copyright 2014 Inside Systems, Inc and is available under the [Apache License, Version 2.0] [apache-license].
+The Ruby implementation is copyright 2014 Inside Systems, Inc and is available under the [Apache License, Version 2.0][apache-license].
 
-The Java/Scala port is copyright 2012-2014 [Snowplow Analytics Ltd] [snowplow-analytics] and is available under the [Apache License, Version 2.0] [apache-license].
+The Java/Scala port is copyright 2012-2014 [Snowplow Analytics Ltd][snowplow-analytics] and is available under the [Apache License, Version 2.0][apache-license].
 
-The Python port is copyright 2012-2014 [Don Spaulding] [donspaulding] and is available under the [Apache License, Version 2.0] [apache-license].
+The Python port is copyright 2012-2014 [Don Spaulding][donspaulding] and is available under the [Apache License, Version 2.0][apache-license].
 
-The node.js (JavaScript) port is copyright 2013-2014 [Martin Katrenik] [mkatrenik] and is available under the [Apache License, Version 2.0] [apache-license].
+The node.js (JavaScript) port is copyright 2013-2014 [Martin Katrenik][mkatrenik] and is available under the [Apache License, Version 2.0][apache-license].
 
-The .NET (C#) port is copyright 2013-2014 [iPerform Software] [iperform] and is available under the [Apache License, Version 2.0] [apache-license].
+The .NET (C#) port is copyright 2013-2014 [iPerform Software][iperform] and is available under the [Apache License, Version 2.0][apache-license].
 
-The PHP port is copyright 2013-2014 [Lars Strojny] [lstrojny] and is available under the [MIT License] [mit-license].
+The PHP port is copyright 2013-2014 [Lars Strojny][lstrojny] and is available under the [MIT License][mit-license].
 
-The Go port is copyright 2014 [Thomas Sileo] [tsileo] and is available under the [MIT License] [mit-license].
+The Go port is copyright 2014 [Thomas Sileo][tsileo] and is available under the [MIT License][mit-license].
 
 [ua-parser]: https://github.com/tobie/ua-parser
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,10 +1,10 @@
 # referer-parser .NET library
 
-This is the .NET implementation of [referer-parser] [referer-parser], the library for extracting attribution data from referer _(sic)_ URLs.
+This is the .NET implementation of [referer-parser][referer-parser], the library for extracting attribution data from referer _(sic)_ URLs.
 
-The implementation uses the shared 'database' of known referers found in [`referers.yml`] [referers-yml].
+The implementation uses the shared 'database' of known referers found in [`referers.yml`][referers-yml].
 
-The .NET version of referer-parser is maintained by [Sepp Wijnands] [swijnands] at [iPerform Software] [iperform].
+The .NET version of referer-parser is maintained by [Sepp Wijnands][swijnands] at [iPerform Software][iperform].
 
 ## C\# 
 
@@ -41,9 +41,9 @@ A NuGet Package is available, under package id RefererParser.
 
 ## Copyright and license
 
-The referer-parser .NET (C#) library is copyright 2013 [iPerform Software] [iperform].
+The referer-parser .NET (C#) library is copyright 2013 [iPerform Software][iperform].
 
-Licensed under the [Apache License, Version 2.0] [license] (the "License");
+Licensed under the [Apache License, Version 2.0][license] (the "License");
 you may not use this software except in compliance with the License.
 
 Unless required by applicable law or agreed to in writing, software

--- a/go/README.md
+++ b/go/README.md
@@ -1,10 +1,10 @@
 # referer-parser Go library
 
-This is the Go implementation of [referer-parser] [referer-parser], the library for extracting search marketing data from referer _(sic)_ URLs.
+This is the Go implementation of [referer-parser][referer-parser], the library for extracting search marketing data from referer _(sic)_ URLs.
 
-The implementation uses the shared 'database' of known referers found in [`referers.yml`] [referers-yml].
+The implementation uses the shared 'database' of known referers found in [`referers.yml`][referers-yml].
 
-The Go version of referer-parser is maintained by [Thomas Sileo] [tsileo].
+The Go version of referer-parser is maintained by [Thomas Sileo][tsileo].
 
 ## Installation
 
@@ -39,7 +39,7 @@ func main() {
 
 ## referers.yml embed
 
-The [`referers.json`] [referers-yml] is embedded in the package using [`go-bindata`] [go-bindata].
+The [`referers.json`][referers-yml] is embedded in the package using [`go-bindata`][go-bindata].
 
 ```
 $ go-bindata -ignore=\\.yml -pkg refererparser data/...

--- a/java-scala/README.md
+++ b/java-scala/README.md
@@ -1,10 +1,10 @@
 # referer-parser Java/Scala library
 
-This is the Java and Scala implementation of [referer-parser] [referer-parser], the library for extracting attribution data from referer _(sic)_ URLs.
+This is the Java and Scala implementation of [referer-parser][referer-parser], the library for extracting attribution data from referer _(sic)_ URLs.
 
-The implementation uses the shared 'database' of known referers found in [`referers.yml`] [referers-yml].
+The implementation uses the shared 'database' of known referers found in [`referers.yml`][referers-yml].
 
-The Scala implementation is a core component of [Snowplow] [snowplow], the open-source web-scale analytics platform powered by Hadoop, Hive and Redshift.
+The Scala implementation is a core component of [Snowplow][snowplow], the open-source web-scale analytics platform powered by Hadoop, Hive and Redshift.
 
 ## Java
 
@@ -133,7 +133,7 @@ val refererParser = "com.snowplowanalytics" %% "referer-parser" % "0.3.0"
 
 The referer-parser Java/Scala library is copyright 2012-2015 Snowplow Analytics Ltd.
 
-Licensed under the [Apache License, Version 2.0] [license] (the "License");
+Licensed under the [Apache License, Version 2.0][license] (the "License");
 you may not use this software except in compliance with the License.
 
 Unless required by applicable law or agreed to in writing, software

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -1,10 +1,10 @@
 # referer-parser node.js (JavaScript) library
 
-This is the node.js (JavaScript) implementation of [referer-parser] [referer-parser], the library for extracting search marketing data from referer _(sic)_ URLs.
+This is the node.js (JavaScript) implementation of [referer-parser][referer-parser], the library for extracting search marketing data from referer _(sic)_ URLs.
 
-The implementation uses the shared 'database' of known referers found in [`referers.yml`] [referers-yml]
+The implementation uses the shared 'database' of known referers found in [`referers.yml`][referers-yml]
 
-The Javascript version of referer-parser is maintained by [Martin Katrenik] [mkatrenik].
+The Javascript version of referer-parser is maintained by [Martin Katrenik][mkatrenik].
 
 ## Installation
 
@@ -59,7 +59,7 @@ console.log(r.uri)                // result of require('url').parse(...)
 
 The referer-parser node.js (JavaScript) library is copyright 2013 Martin Katrenik.
 
-Licensed under the [Apache License, Version 2.0] [license] (the "License");
+Licensed under the [Apache License, Version 2.0][license] (the "License");
 you may not use this software except in compliance with the License.
 
 Unless required by applicable law or agreed to in writing, software

--- a/php/README.md
+++ b/php/README.md
@@ -1,10 +1,10 @@
 # referer-parser PHP library
 
-This is the PHP implementation of [referer-parser] [referer-parser], the library for extracting search marketing data from referer _(sic)_ URLs.
+This is the PHP implementation of [referer-parser][referer-parser], the library for extracting search marketing data from referer _(sic)_ URLs.
 
-The implementation uses the shared 'database' of known referers found in [`referers.yml`] [referers-yml].
+The implementation uses the shared 'database' of known referers found in [`referers.yml`][referers-yml].
 
-The PHP version of referer-parser is maintained by [Lars Strojny] [lstrojny].
+The PHP version of referer-parser is maintained by [Lars Strojny][lstrojny].
 
 ## Installation
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,10 +1,10 @@
 # referer-parser Python library
 
-This is the Python implementation of [referer-parser] [referer-parser], the library for extracting search marketing data from referer _(sic)_ URLs.
+This is the Python implementation of [referer-parser][referer-parser], the library for extracting search marketing data from referer _(sic)_ URLs.
 
-The implementation uses the shared 'database' of known referers found in [`referers.yml`] [referers-yml].
+The implementation uses the shared 'database' of known referers found in [`referers.yml`][referers-yml].
 
-The Python version of referer-parser is maintained by [Don Spaulding] [donspaulding].
+The Python version of referer-parser is maintained by [Don Spaulding][donspaulding].
 
 ## Installation
 
@@ -82,7 +82,7 @@ The distribution process for Python looks like this:
 
 The referer-parser Python library is copyright 2012-2016 Don Spaulding.
 
-Licensed under the [Apache License, Version 2.0] [license] (the "License");
+Licensed under the [Apache License, Version 2.0][license] (the "License");
 you may not use this software except in compliance with the License.
 
 Unless required by applicable law or agreed to in writing, software

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,8 +1,8 @@
 # referer-parser Ruby library
 
-This is the Ruby implementation of [referer-parser] [referer-parser], the library for extracting search marketing data from referer _(sic)_ URLs.
+This is the Ruby implementation of [referer-parser][referer-parser], the library for extracting search marketing data from referer _(sic)_ URLs.
 
-The implementation uses the shared 'database' of known referers found in [`referers.yml`] [referers-yml].
+The implementation uses the shared 'database' of known referers found in [`referers.yml`][referers-yml].
 
 ## Installation
 
@@ -83,7 +83,7 @@ parser.parse('http://www.google.com/search?q=gateway+oracle+cards+denise+linn&hl
 
 The referer-parser Ruby library is copyright 2014 Inside Systems, Inc.
 
-Licensed under the [Apache License, Version 2.0] [license] (the "License");
+Licensed under the [Apache License, Version 2.0][license] (the "License");
 you may not use this software except in compliance with the License.
 
 Unless required by applicable law or agreed to in writing, software


### PR DESCRIPTION
Fixes a few links broken by the [formal GFM spec](https://githubengineering.com/a-formal-spec-for-github-markdown/) back in March 2017.